### PR TITLE
Add GitHub Actions workflow for automatic PR updates from upstream re…

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,17 @@
+name: Upstream to PR
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@master
+    with:
+      upstream_repository: https://github.com/ROCm/device-metrics-exporter
+      upstream_branch: main
+      team_reviewers: 'mlops'
+    secrets:
+      personal_access_token: ${{ secrets.GH_AUTO_PR }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of creating pull requests from an upstream repository. The workflow is scheduled to run daily and can also be triggered manually.

Key changes:

* **New GitHub Actions Workflow**:
  * [`.github/workflows/auto-pr.yml`](diffhunk://#diff-66bcf23e63818b74faef47f7f8df000b744f92840970c2e649b491adf936c8a1R1-R17): Added a new workflow named "Upstream to PR" that schedules a job to run daily at noon and allows manual triggering. The job uses the `neuro-inc/reuse` workflow to create pull requests from the upstream repository `https://github.com/ROCm/device-metrics-exporter` to the current repository. The `mlops` team is assigned as reviewers, and a personal access token is used for authentication.