### PR TITLE
Upstream branch main (revision eb05aa2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker run -d \
 
 ## Documentation
 
-For detailed documentation including installation guides, configuration options, and metric descriptions, see the [documentation](https://dcgpu.docs.amd.com/projects/device-metrics-exporter/en/latest).
+For detailed documentation including installation guides, configuration options, and metric descriptions, see the [documentation](https://instinct.docs.amd.com/projects/device-metrics-exporter/en/latest/).
 
 ## License
 

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -90,7 +90,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.12.0
+rocm-docs-core==1.13.0
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -11,8 +11,8 @@ keywords:
   - prometheus
 
 type: application
-version: v1.1.0
-appVersion: "v1.1.0"
+version: v1.2.0
+appVersion: "v1.2.0"
 kubeVersion: ">= 1.29.0-0"
 
 maintainers:

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -11,8 +11,8 @@ keywords:
   - prometheus
 
 type: application
-version: v1.0.0
-appVersion: "v1.0.0"
+version: v1.1.0
+appVersion: "v1.1.0"
 kubeVersion: ">= 1.29.0-0"
 
 maintainers:

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -1,6 +1,6 @@
 # amdgpu-metrics-exporter-charts
 
-![Version: v1.0.0](https://img.shields.io/badge/Version-v1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: v1.1.0](https://img.shields.io/badge/Version-v1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.1.0](https://img.shields.io/badge/AppVersion-v1.1.0-informational?style=flat-square)
 
 A Helm chart for AMD GPU Metric Exporter
 
@@ -24,7 +24,7 @@ Kubernetes: `>= 1.29.0-0`
 | image.pullPolicy | string | `"Always"` | metrics exporter image pullPolicy |
 | image.pullSecrets | string | `""` | metrics exporter image pullSecret name |
 | image.repository | string | `"docker.io/rocm/device-metrics-exporter"` | repository URL for the metrics exporter image |
-| image.tag | string | `"v1.0.0"` | metrics exporter image tag |
+| image.tag | string | `"v1.1.0"` | metrics exporter image tag |
 | nodeSelector | object | `{}` | Add node selector for the daemonset of metrics exporter |
 | platform | string | `"k8s"` |  |
 | service.ClusterIP.port | int | `5000` | set port for ClusterIP type service |

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -1,6 +1,6 @@
-# amdgpu-metrics-exporter-charts
+# device-metrics-exporter-charts
 
-![Version: v1.1.0](https://img.shields.io/badge/Version-v1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.1.0](https://img.shields.io/badge/AppVersion-v1.1.0-informational?style=flat-square)
+![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 A Helm chart for AMD GPU Metric Exporter
 
@@ -24,7 +24,8 @@ Kubernetes: `>= 1.29.0-0`
 | image.pullPolicy | string | `"Always"` | metrics exporter image pullPolicy |
 | image.pullSecrets | string | `""` | metrics exporter image pullSecret name |
 | image.repository | string | `"docker.io/rocm/device-metrics-exporter"` | repository URL for the metrics exporter image |
-| image.tag | string | `"v1.1.0"` | metrics exporter image tag |
+| image.tag | string | `"v1.2.0"` | metrics exporter image tag |
+| image.initContainerImage | string | `"busybox:1.36"` | metrics exporter initContainer image |
 | nodeSelector | object | `{}` | Add node selector for the daemonset of metrics exporter |
 | platform | string | `"k8s"` |  |
 | service.ClusterIP.port | int | `5000` | set port for ClusterIP type service |

--- a/helm-charts/templates/daemonsets.yaml
+++ b/helm-charts/templates/daemonsets.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-amdgpu-metrics-exporter
     spec:
+      serviceAccountName: amdgpu-metrics-exporter
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
@@ -24,7 +25,7 @@ spec:
         - -c
         - while [ ! -d /host-sys/class/kfd ] || [ ! -d /host-sys/module/amdgpu/drivers/
           ]; do echo "amdgpu driver is not loaded "; sleep 2 ;done
-        image: busybox:1.36
+        image: {{ .Values.image.initContainerImage }}
         imagePullPolicy: IfNotPresent
         name: driver-init
         securityContext:
@@ -64,6 +65,8 @@ spec:
             name: sys-volume
           - mountPath: /var/lib/kubelet/pod-resources
             name: pod-resources
+          - mountPath: /var/lib/amd-metrics-exporter
+            name: exporter-health-grpc-volume
           {{- if .Values.configMap }}
           - name: metrics-config-volume
             mountPath: /etc/metrics/
@@ -86,6 +89,10 @@ spec:
           path: /var/lib/kubelet/pod-resources
           type: Directory
         name: pod-resources
+      - hostPath:
+          path: /var/lib/amd-metrics-exporter
+          type: DirectoryOrCreate
+        name: exporter-health-grpc-volume
       {{- if .Values.configMap }}
       - name: metrics-config-volume
         configMap:

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- repository URL for the metrics exporter image
   repository: docker.io/rocm/device-metrics-exporter
   # -- metrics exporter image tag
-  tag: v1.0.0
+  tag: v1.1.0
   # -- metrics exporter image pullPolicy
   pullPolicy: Always
   # -- metrics exporter image pullSecret name

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -7,11 +7,13 @@ image:
   # -- repository URL for the metrics exporter image
   repository: docker.io/rocm/device-metrics-exporter
   # -- metrics exporter image tag
-  tag: v1.1.0
+  tag: v1.2.0
   # -- metrics exporter image pullPolicy
   pullPolicy: Always
   # -- metrics exporter image pullSecret name
   pullSecrets: ""
+  # -- metrics exporter initContainer image
+  initContainerImage: busybox:1.36
 
 service:
   # -- metrics exporter service type, could be ClusterIP or NodePort


### PR DESCRIPTION
Integrating latest changes from [ROCm/device-metrics-exporter](https://github.com/ROCm/device-metrics-exporter) branch main

eb05aa20597d7bd75a2c11fd0a29626eceb9964a Merge pull request ROCm/device-metrics-exporter#35 from OrenLeung/patch-1
086d8bdaf89cbd731499ebc99ee423fbc6efe5ff Update README.md
bc794a8092d48eb0d6506b330c537234e7498137 Update helm charts to v1.2.0 (ROCm/device-metrics-exporter#30)
f4000e4150010b30f6cf7c8055b6d9c7eb16bc1b Merge pull request ROCm/device-metrics-exporter#26 from yansun1996/update_v1.1.0_helm_chart
c95967f3df636ed26add1ebd9525e4e2cc23c7c0 Update helm chart to v1.1.0
57381484616a26db50f8caa8b95d39fd0064c7dd Bump rocm-docs-core from 1.12.0 to 1.13.0 in /docs/sphinx (ROCm/device-metrics-exporter#23)